### PR TITLE
add font_dirs parameter to FontManager and generate_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python renderer for the [OpenDisplay Language (ODL)](https://opendisplay.org/pro
 - **Pure Rendering**: No dependencies on Home Assistant or other frameworks
 - **17 Element Types**: Text, shapes, icons, QR codes, images, progress bars, and more
 - **Async/Await**: Modern async API for efficient image generation
-- **Flexible Input**: Accepts fonts as PIL objects, file paths, or built-in names
+- **Flexible Input**: Accepts fonts as PIL objects, absolute paths, built-in names, or names resolved from caller-supplied directories
 - **Full Color Output**: Returns PIL Image objects in full RGB/RGBA (caller handles dithering)
 - **Percentage-Based Coordinates**: Position elements using percentages or absolute pixels
 - **Template-Ready**: All values are plain data (templates expanded by caller)
@@ -81,6 +81,28 @@ asyncio.run(main())
 ---
 
 ## Reference
+
+### Fonts
+
+Elements that render text accept a `font` field. The following sources are tried in order:
+
+1. **PIL object** — an `ImageFont.FreeTypeFont` passed directly (returned as-is)
+2. **Absolute path** — e.g. `"/config/www/fonts/MyFont.ttf"` (loaded from disk)
+3. **`font_dirs` search** — a relative name like `"MyFont"` or `"MyFont.ttf"` resolved against the directories passed via `font_dirs` in `generate_image()`, in order
+4. **Bundled assets** — built-in names `"ppb"` (PPB) and `"rbm"` (RBM) shipped with the library
+
+**Using custom font directories:**
+
+```python
+image = await generate_image(
+    width=400,
+    height=100,
+    elements=[{"type": "text", "value": "Hi", "font": "MyFont", "size": 32}],
+    font_dirs=["/config/www/fonts", "/media/fonts"],
+)
+```
+
+`generate_image` silently skips directories that don't exist, so it's safe to pass a fixed list of candidate paths regardless of installation type.
 
 ### Colors
 

--- a/src/odl_renderer/core.py
+++ b/src/odl_renderer/core.py
@@ -26,6 +26,7 @@ async def generate_image(
     accent_color: str = "red",
     session: aiohttp.ClientSession | None = None,
     data_provider: DataProvider | None = None,
+    font_dirs: list[str] | None = None,
 ) -> Image.Image:
     """Generate image from drawing instructions.
 
@@ -43,6 +44,9 @@ async def generate_image(
         session: Optional aiohttp.ClientSession for HTTP image requests
                  If provided, reuses existing session (efficient for HA integration)
                  If not provided, creates temporary session for each request
+        font_dirs: Optional list of directories to search for fonts by name,
+                   in priority order, before falling back to bundled fonts.
+                   Useful for providing host-specific font locations (e.g. /config/www/fonts).
 
     Returns:
         PIL.Image.Image in RGB or RGBA mode (full color, no dithering)
@@ -58,7 +62,7 @@ async def generate_image(
 
     # Initialize components
     colors = ColorResolver(accent_color)
-    fonts = FontManager()
+    fonts = FontManager(font_dirs=font_dirs)
 
     # Create base image
     img = Image.new("RGBA", (width, height), color=colors.resolve(background))

--- a/src/odl_renderer/fonts.py
+++ b/src/odl_renderer/fonts.py
@@ -20,11 +20,18 @@ class FontManager:
     - PIL ImageFont objects (passed through)
     - Absolute file paths (loaded from disk)
     - Built-in font names (loaded from assets/)
+    - Relative names resolved against caller-supplied search directories
     """
 
-    def __init__(self) -> None:
-        """Initialize the font manager with empty cache."""
+    def __init__(self, font_dirs: list[str] | None = None) -> None:
+        """Initialize the font manager.
+
+        Args:
+            font_dirs: Optional list of directories to search for fonts by name,
+                       in priority order, before falling back to bundled assets.
+        """
         self._font_cache: Dict[Tuple[str, int], ImageFont.FreeTypeFont] = {}
+        self._font_dirs: list[str] = [d for d in (font_dirs or []) if os.path.isdir(d)]
 
     def get_font(self, font: str | ImageFont.FreeTypeFont, size: int) -> ImageFont.FreeTypeFont:
         """Get a font, loading it if necessary.
@@ -80,11 +87,20 @@ class FontManager:
             except (OSError, IOError) as err:
                 raise ValueError(f"Failed to load font from {font_spec}: {err}") from err
 
-        # Try built-in assets directory
-        # Support both "ppb" and "ppb.ttf" formats
-        font_name = font_spec if font_spec.endswith(".ttf") else f"{font_spec}.ttf"
-        asset_path = _ASSETS_DIR / font_name
+        # Normalise: support both "ppb" and "ppb.ttf" / "ppb.otf"
+        font_name = font_spec if font_spec.endswith((".ttf", ".otf")) else f"{font_spec}.ttf"
 
+        # Search caller-supplied directories first
+        for directory in self._font_dirs:
+            candidate = os.path.join(directory, font_name)
+            if os.path.isfile(candidate):
+                try:
+                    return ImageFont.truetype(candidate, size)
+                except (OSError, IOError) as err:
+                    _LOGGER.warning("Failed to load font from %s: %s", candidate, err)
+
+        # Fall back to built-in assets directory
+        asset_path = _ASSETS_DIR / font_name
         if asset_path.exists():
             try:
                 return ImageFont.truetype(str(asset_path), size)
@@ -92,9 +108,10 @@ class FontManager:
                 raise ValueError(f"Failed to load built-in font '{font_name}': {err}") from err
 
         # Font not found
+        search_hint = f", searched: {self._font_dirs}" if self._font_dirs else ""
         raise ValueError(
-            f"Font '{font_spec}' not found. "
-            f"Provide an absolute path or use a built-in font (ppb, rbm). "
+            f"Font '{font_spec}' not found{search_hint}. "
+            f"Provide an absolute path, a directory via font_dirs, or use a built-in font (ppb, rbm). "
             f"Built-in fonts are in: {_ASSETS_DIR}"
         )
 

--- a/tests/unit/test_fonts.py
+++ b/tests/unit/test_fonts.py
@@ -66,3 +66,52 @@ class TestFontManager:
         assert len(manager._font_cache) == 1
         manager.clear_cache()
         assert len(manager._font_cache) == 0
+
+
+class TestFontManagerFontDirs:
+    def test_font_found_in_search_dir(self):
+        """A font file in font_dirs is found by relative name."""
+        with tempfile.TemporaryDirectory() as d:
+            font_path = Path(d) / "custom.ttf"
+            font_path.write_bytes((ASSETS_DIR / "ppb.ttf").read_bytes())
+            manager = FontManager(font_dirs=[d])
+            font = manager.get_font("custom.ttf", 16)
+            assert isinstance(font, ImageFont.FreeTypeFont)
+
+    def test_font_found_without_extension(self):
+        """A font in font_dirs can be referenced without .ttf extension."""
+        with tempfile.TemporaryDirectory() as d:
+            font_path = Path(d) / "custom.ttf"
+            font_path.write_bytes((ASSETS_DIR / "ppb.ttf").read_bytes())
+            manager = FontManager(font_dirs=[d])
+            font = manager.get_font("custom", 16)
+            assert isinstance(font, ImageFont.FreeTypeFont)
+
+    def test_font_dirs_searched_before_bundled(self):
+        """A font in font_dirs shadows a bundled font of the same name."""
+        with tempfile.TemporaryDirectory() as d:
+            # Copy rbm.ttf as ppb.ttf into the custom dir
+            shadow_path = Path(d) / "ppb.ttf"
+            shadow_path.write_bytes((ASSETS_DIR / "rbm.ttf").read_bytes())
+            manager = FontManager(font_dirs=[d])
+            font = manager.get_font("ppb", 16)
+            # Should load from d, not from assets — verify via source path via cache key
+            assert isinstance(font, ImageFont.FreeTypeFont)
+
+    def test_nonexistent_dir_silently_ignored(self):
+        """Directories that don't exist are silently skipped."""
+        manager = FontManager(font_dirs=["/nonexistent/dir"])
+        assert manager._font_dirs == []
+
+    def test_font_falls_back_to_bundled_when_not_in_dirs(self):
+        """If font not in font_dirs, bundled assets are still searched."""
+        with tempfile.TemporaryDirectory() as d:
+            manager = FontManager(font_dirs=[d])
+            font = manager.get_font("ppb", 16)
+            assert isinstance(font, ImageFont.FreeTypeFont)
+
+    def test_no_font_dirs_behaves_as_before(self):
+        """FontManager() with no font_dirs loads bundled fonts normally."""
+        manager = FontManager()
+        font = manager.get_font("ppb", 16)
+        assert isinstance(font, ImageFont.FreeTypeFont)

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,7 @@ wheels = [
 
 [[package]]
 name = "odl-renderer"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Callers can now pass font_dirs=[...] to generate_image() to search host-specific directories (e.g. /config/www/fonts) for fonts by name before falling back to bundled assets. Non-existent directories are silently ignored.