### PR TITLE
chore: move test/dev dependencies from extras to dependency groups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
 
       - name: Run prek
         run: uv run prek run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = [
-    "pytest>=9.0.3",
-    "pytest-asyncio>=1.3.0",
-    "pytest-cov>=7.1.0",
-    "pytest-xdist>=3.8.0",
-    "time-machine>=2.9.0",
-]
-
 visual = [
     "syrupy>=5.1.0",
     "imagehash>=4.3.2"
@@ -49,11 +41,6 @@ property = [
     "hypothesis>=6.151.12"
 ]
 
-dev = [
-    "mypy>=1.20.0",
-    "ruff>=0.15.10",
-    "prek>=0.3.4",
-]
 [project.urls]
 Homepage = "https://github.com/g4bri3lDev/odl-renderer"
 Repository = "https://github.com/g4bri3lDev/odl-renderer"
@@ -79,3 +66,18 @@ warn_unused_configs = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.20.0",
+    "ruff>=0.15.10",
+    "prek>=0.3.4",
+    { include-group = "test" },
+]
+test = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
+    "time-machine>=2.9.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,7 @@ wheels = [
 
 [[package]]
 name = "odl-renderer"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -817,13 +817,24 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+property = [
+    { name = "hypothesis" },
+]
+visual = [
+    { name = "imagehash" },
+    { name = "syrupy" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "prek" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
-]
-property = [
-    { name = "hypothesis" },
+    { name = "time-machine" },
 ]
 test = [
     { name = "pytest" },
@@ -832,30 +843,37 @@ test = [
     { name = "pytest-xdist" },
     { name = "time-machine" },
 ]
-visual = [
-    { name = "imagehash" },
-    { name = "syrupy" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "hypothesis", marker = "extra == 'property'", specifier = ">=6.151.12" },
     { name = "imagehash", marker = "extra == 'visual'", specifier = ">=4.3.2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.0" },
     { name = "pillow", specifier = ">=12.0.0" },
-    { name = "prek", marker = "extra == 'dev'", specifier = ">=0.3.4" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.1.0" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "qrcode", extras = ["pil"], specifier = ">=7.4.2" },
     { name = "resize-image", specifier = ">=0.4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
     { name = "syrupy", marker = "extra == 'visual'", specifier = ">=5.1.0" },
-    { name = "time-machine", marker = "extra == 'test'", specifier = ">=2.9.0" },
 ]
-provides-extras = ["test", "visual", "property", "dev"]
+provides-extras = ["visual", "property"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.20.0" },
+    { name = "prek", specifier = ">=0.3.4" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "ruff", specifier = ">=0.15.10" },
+    { name = "time-machine", specifier = ">=2.9.0" },
+]
+test = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "time-machine", specifier = ">=2.9.0" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

Same change as OpenDisplay/py-opendisplay#112: `test` and `dev` lived in `[project.optional-dependencies]` (extras). Extras are not installed by a plain `uv run`, so `uv run pytest` in a fresh checkout or worktree silently fell back to whatever pytest is on $PATH — running tests under a different interpreter against whatever `odl_renderer` *that* interpreter could import, instead of the tree under test. Dev tooling is also not publishable package metadata, so `[dependency-groups]` is the semantically right home.

- `test` and `dev` moved to `[dependency-groups]`; `dev` includes `test`
- `visual` and `property` stay extras — they gate optional test suites, and the visual tests import `imagehash`/`syrupy` unconditionally, so the full suite still needs `--all-extras` (unchanged)
- `lint.yml`: `uv sync --extra dev` → `uv sync` (the dev group is installed by default; the extra no longer exists)
- `test.yml`/`generate-screenshots.yml` `uv sync --all-extras` keep working (dev group is default)
- `uv lock` also refreshed the lockfile's stale self-version (0.5.10 → 0.5.11, pyproject was already bumped)

## Test plan

- [x] fresh venv, `uv run --all-extras pytest -q` → 402 passed (pytest resolved from `.venv`, not PATH)
- [x] `uv lock` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)